### PR TITLE
chore: return standard cancellation error

### DIFF
--- a/codex/download_test.go
+++ b/codex/download_test.go
@@ -111,11 +111,11 @@ func TestDownloadStreamCancelled(t *testing.T) {
 	err := <-channelError
 
 	if err == nil {
-		t.Fatal("UploadFile should have been canceled")
+		t.Fatal("DownloadStream should have been canceled")
 	}
 
-	if err.Error() != "Failed to stream file: Stream EOF!" {
-		t.Fatalf("UploadFile returned unexpected error: %v", err)
+	if err.Error() != context.Canceled.Error() {
+		t.Fatalf("DownloadStream returned unexpected error: %v", err)
 	}
 }
 

--- a/codex/upload_test.go
+++ b/codex/upload_test.go
@@ -62,8 +62,8 @@ func TestUploadReaderCancel(t *testing.T) {
 		t.Fatal("UploadReader should have been canceled")
 	}
 
-	if err.Error() != "upload canceled" {
-		t.Fatalf("UploadReader returned unexpected error: %v", err)
+	if err.Error() != context.Canceled.Error() {
+		t.Fatalf("UploadReader returned unexpected error: %v expected %v", err, context.Canceled)
 	}
 }
 
@@ -134,7 +134,7 @@ func TestUploadFileCancel(t *testing.T) {
 		t.Fatal("UploadFile should have been canceled")
 	}
 
-	if err.Error() != "Failed to upload the file: Failed to stream the file: Stream Closed!" {
+	if err.Error() != context.Canceled.Error() {
 		t.Fatalf("UploadFile returned unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
This PR return the standard `context.Canceled` when a context is cancelled 