### PR TITLE
makes sure we are having Nat set to None for the tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ update: | submodules
 
 libcodex:
 	@echo "Building libcodex..."
-	@$(MAKE) -C $(NIM_CODEX_DIR) libcodex
+	@$(MAKE) -C $(NIM_CODEX_DIR) libcodex CODEX_LIB_PARAMS="-d:codex_enable_api_debug_peers"
 
 build:
 	@echo "Building Codex Go Bindings..."
@@ -30,6 +30,14 @@ build:
 test:
 	@echo "Running tests..."
 	CGO_ENABLED=1 CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" GOTESTFLAGS="-timeout=2m" go test ./...
+
+test2:
+	@echo "Running tests..."
+	CGO_ENABLED=1 CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" GOTESTFLAGS="-timeout=2m" gotestsum --packages="./..." -f testname -- -count 1 -run TestConnectWithAddress
+
+test3:
+	@echo "Running tests..."
+	CGO_ENABLED=1 CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" GOTESTFLAGS="-timeout=2m" gotestsum --packages="./..." -f testname -- -count 1
 
 clean:
 	@echo "Cleaning up..."

--- a/codex/p2p_test.go
+++ b/codex/p2p_test.go
@@ -36,6 +36,7 @@ func TestConnectWithAddress(t *testing.T) {
 		LogFormat:      LogFormatNoColors,
 		MetricsEnabled: false,
 		DiscoveryPort:  8090,
+		Nat:            "none",
 	})
 	if err != nil {
 		t.Fatalf("Failed to create codex1: %v", err)
@@ -50,6 +51,7 @@ func TestConnectWithAddress(t *testing.T) {
 		LogFormat:      LogFormatNoColors,
 		MetricsEnabled: false,
 		DiscoveryPort:  8091,
+		Nat:            "none",
 	})
 	if err != nil {
 		t.Fatalf("Failed to create codex2: %v", err)

--- a/codex/testutil.go
+++ b/codex/testutil.go
@@ -15,6 +15,7 @@ func defaultConfigHelper(t *testing.T) Config {
 		MetricsEnabled: false,
 		BlockRetries:   3000,
 		LogLevel:       "ERROR",
+		Nat:            "none",
 	}
 }
 
@@ -42,6 +43,11 @@ func newCodexNode(t *testing.T, opts ...Config) *CodexNode {
 
 		if c.DiscoveryPort != 0 {
 			config.DiscoveryPort = c.DiscoveryPort
+		}
+
+		// in case someone wants to change the config.Nat default value
+		if c.Nat != "" {
+			config.Nat = c.Nat
 		}
 	}
 


### PR DESCRIPTION
1. Use `Nat: "none"` in tests so that multiple nodes can be started in one process without crashes.
2. Considers using `gotestsum` in `make test` (I made example in `make test2` and `make test3`). It is more suitable for CI and makes it easier to see which tests are failing.