### PR TITLE
Fix: use Nat: "none" in recently added tests

### DIFF
--- a/codex/codex_test.go
+++ b/codex/codex_test.go
@@ -100,6 +100,7 @@ func TestCreateAndDestroyMultipleInstancesWithSameDatadir(t *testing.T) {
 		LogFormat:      LogFormatNoColors,
 		MetricsEnabled: false,
 		BlockRetries:   5,
+		Nat:            "none",
 	}
 
 	for range 2 {

--- a/codex/p2p_test.go
+++ b/codex/p2p_test.go
@@ -36,6 +36,7 @@ func TestConnectWithAddress(t *testing.T) {
 		LogFormat:      LogFormatNoColors,
 		MetricsEnabled: false,
 		DiscoveryPort:  8090,
+		Nat:            "none",
 	})
 	if err != nil {
 		t.Fatalf("Failed to create codex1: %v", err)


### PR DESCRIPTION
There are some new tests and they are missing `Nat: "none"` setting which causes seg faults when running them.