### PR TITLE
fix: updates module name from logos-go-bindings to logos-storage-go-bindings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/logos-storage/logos-go-bindings
+module github.com/logos-storage/logos-storage-go-bindings
 
 go 1.24.0


### PR DESCRIPTION
Should fix: https://github.com/logos-storage/logos-storage-go-bindings/issues/20#issuecomment-3792527796.